### PR TITLE
flow 0.53 compatibility

### DIFF
--- a/jsx-control-statements.flow.js
+++ b/jsx-control-statements.flow.js
@@ -1,7 +1,7 @@
 // @flow
 
-declare var If: ReactClass<{condition: boolean}>;
-declare var For: ReactClass<{each: string, index: string, of: Array<any>}>;
-declare var Choose: ReactClass<{}>;
-declare var When: ReactClass<{condition: boolean}>;
-declare var Otherwise: ReactClass<{}>;
+declare var If: React$ComponentType<{condition: boolean}>;
+declare var For: React$ComponentType<{each: string, index: string, of: Array<any>}>;
+declare var Choose: React$ComponentType<{}>;
+declare var When: React$ComponentType<{condition: boolean}>;
+declare var Otherwise: React$ComponentType<{}>;


### PR DESCRIPTION
flow 0.53 changed how React things are typed. They've provided a `flow-upgrade` utility to automatically convert things, so I've ran that to generate the changes in this commit.