### PR TITLE
Update to babel 7

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,12 +32,12 @@
     "cover": "istanbul cover -x \"**/spec/**\" node_modules/mocha/bin/_mocha spec/*.js"
   },
   "dependencies": {
-    "babel-core": "^6.1.2",
-    "babel-plugin-syntax-jsx": "^6.1.18"
+    "@babel/core": "^7.1.2",
+    "@babel/register": "^7.0.0"
   },
   "devDependencies": {
-    "babel-eslint": "^6.0.3",
-    "babel-preset-react": "^6.1.2",
+    "@babel/preset-react": "^7.0.0",
+    "babel-eslint": "^10.0.1",
     "chai": "^3.5.0",
     "chai-spies": "^0.7.1",
     "coveralls": "^2.11.6",

--- a/spec/tests.js
+++ b/spec/tests.js
@@ -1,7 +1,7 @@
 var plugin = require("../src/index");
 
-require("babel-core/register")({
-  presets: ["babel-preset-react"],
+require("@babel/register")({
+  presets: ["@babel/preset-react"],
   plugins: [plugin],
   cache: false
 });

--- a/src/index.js
+++ b/src/index.js
@@ -24,7 +24,6 @@ module.exports = function jcsPlugin(babel) {
   };
 
   return {
-    inherits: require("babel-plugin-syntax-jsx"),
     visitor: visitor
   };
 };


### PR DESCRIPTION
I updated to latest Babel packages. 

I had to remove the babel-plugin-syntax-jsx package as it was giving me errors after update. Even if I updated to latest @babel/plugin-syntax-jsx. But everything seems to work without it. All test passed and I could not find any reason for it as both jsx and js files worked fine. Might be because I'm using webpack not sure.