### PR TITLE
Adds TChildren type fur children functions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -19,6 +19,7 @@ declare namespace JSX {
     | string
     | number
     | boolean
+    | ((props: any) => TChildren)
     | null
     | typeof undefined;
 


### PR DESCRIPTION
Hi this is adding a type for `TChildren` that allows components with children with render functions, without this, we have a TS error for the following:

```ts
function Component() {
  return (
     <SomeOtherComponent>
      {(props) => (<div>{props.something}</div>)}
     </SomeOtherComponent>
  )
}
```