### PR TITLE
Fix children types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,29 +1,15 @@
-declare function Choose(): any;
-declare function When(props: { condition: boolean }): any;
-declare function Otherwise(): any;
-declare function If(props: { condition: boolean }): any;
+declare function Choose(props: { children: React.ReactNode }): any;
+declare function When(props: { condition: boolean, children: React.ReactNode }): any;
+declare function Otherwise(props: { children: React.ReactNode }): any;
+declare function If(props: { condition: boolean, children: React.ReactNode }): any;
 declare function For<T>(props: {
   each: string;
   of: Iterable<T>;
   index?: string;
+  children: React.ReactNode
 }): any;
 declare function For<T>(props: {
   of: Iterable<T>;
   body: (item: T, index?: number) => React.ReactNode;
 }): any;
-declare function With(props: { [id: string]: any }): any;
-
-declare namespace JSX {
-  type TChildren =
-    | Element
-    | string
-    | number
-    | boolean
-    | ((props: any) => TChildren)
-    | null
-    | typeof undefined;
-
-  interface IntrinsicAttributes {
-    children?: TChildren | TChildren[];
-  }
-}
+declare function With(props: { [id: string]: any, children: React.ReactNode }): any;


### PR DESCRIPTION
This is the fix for the problem described in #108 

- The `TChildren` type is replaced with `React.ReactNode` ([why](https://github.com/typescript-cheatsheets/react/blob/main/README.md#useful-react-prop-type-examples))
- The `children` prop is now specified only for the relevant function declarations and not on the `IntrinsicAttributes` interface

Resolves #108 