### PR TITLE
Typo error fixed.

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 _JSX-Control-Statements_ is a Babel plugin that extends JSX to add basic control statements: **conditionals** and **loops**.
 It does so by transforming component-like control statements to their JavaScript counterparts - e.g. `<If condition={condition()}>Hello World!</If>` becomes `condition() ? 'Hello World!' : null`.
 
-Developers coming to React from using JavaScript templating libraries like Handlebars are often surprised that there's no built-in looping or conditional syntax. This is by design - JSX by is not a templating library, it's declarative syntactic sugar over functional JavaScript expressions. JSX Control Statements follows the same principle - it provides a component-like syntax that keeps your `render` functions neat and readable, but desugars into clean, readable JavaScript.
+Developers coming to React from using JavaScript templating libraries like Handlebars are often surprised that there's no built-in looping or conditional syntax. This is by design - JSX is not a templating library, it's declarative syntactic sugar over functional JavaScript expressions. JSX Control Statements follows the same principle - it provides a component-like syntax that keeps your `render` functions neat and readable, but desugars into clean, readable JavaScript.
 
 The only dependency _JSX-Control-Statements_ relies upon is _Babel_. It is compatible with React and React Native.
 


### PR DESCRIPTION
There is a typo error in the second paragraph of the introductory section. The second line of this paragraph is written as, "This is by design - JSX by is not a templating library, it's declarative syntactic sugar over functional JavaScript expressions."
The correct line could be written as, " This is by design - JSX is not a templating library, it's declarative syntactic sugar over functional JavaScript expressions." (avoid using 'by' after JSX).

Thank you.